### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/api/v3/EntityMessage.php
+++ b/api/v3/EntityMessage.php
@@ -24,7 +24,7 @@ function _civicrm_api3_entity_message_create_spec(&$spec) {
  * @param array $params
  *
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_entity_message_create($params) {
   $params['entity_id'] = CRM_Core_Config::domainID();
@@ -38,7 +38,7 @@ function civicrm_api3_entity_message_create($params) {
  *
  * @return array
  *   API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_entity_message_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -51,7 +51,7 @@ function civicrm_api3_entity_message_delete($params) {
  *
  * @return array
  *   API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_entity_message_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);

--- a/api/v3/Message.php
+++ b/api/v3/Message.php
@@ -18,7 +18,7 @@ function _civicrm_api3_message_create_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_message_create($params) {
   if (empty($params['id']) && empty($params['name'])) {
@@ -44,7 +44,7 @@ function civicrm_api3_message_create($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_message_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -55,7 +55,7 @@ function civicrm_api3_message_delete($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_message_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.